### PR TITLE
Add tonc-specific styling + general visual cleanup

### DIFF
--- a/content/affobj.md
+++ b/content/affobj.md
@@ -683,6 +683,10 @@ For anchoring, you actually need one set of coordinates for each coordinate-spac
 <div class="lblock">
 
 <table border=0 cellpadding=1 cellspacing=0>
+<colgroup>
+    <col span="1" style="width: 14%;">
+    <col span="1" style="width: 86%;">
+</colgroup>
 <tbody valign="top">
 <tr align="left"> <th width=48>point</th>		<th>description</th> </tr>
 <tr>

--- a/content/dma.md
+++ b/content/dma.md
@@ -37,7 +37,7 @@ Every kind of transfer routine needs 3 things: a source, a destination and the a
 The use of the source and destination registers should be obvious. The control register needs some explaining. Although the `REG_DMAxCNT` registers themselves are 32bits, they are often split into two separate registers: one for the count, and one for the actual control bits.
 
 <div class="reg">
-<table class="reg" id="tbl:reg-dmaxcnt"
+<table class="reg reg-huge" id="tbl:reg-dmaxcnt"
   border=1 frame=void cellPadding=4 cellSpacing=0>
 <caption class="reg">
   REG_DMAxCNT @ <code>0400:00B8</code>+12<i>x</i>

--- a/content/gfx.md
+++ b/content/gfx.md
@@ -241,7 +241,7 @@ Note that in these examples the sum of the weights is 1, so that the final color
 Backgrounds are always enabled for blending. To enable sprite-blending, set `OBJ_ATTR.attr0`\{a\}. There are three registers that control blending, which unfortunately go by many different names. The ones I use are `REG_BLDCNT`, `REG_BLDALPHA` and `REG_BLDY`. Other names are `REG_BLDMOD`, `REG_COLEV` and `REG_COLEY`, and sometimes the ‘E’ in the last two is removed. Be warned. Anyway, the first says how and on which layers the blend should be performed, the last two contain the weights. Oh, since the GBA doesn't do floating point, the weights are [fixed-point](fixed.html) numbers in 1.4 format. Still limited by 0 and 1, of course, so there are 17 blend levels.
 
 <div class="reg">
-  <table class="reg" id="tbl:reg-bldcnt" border=1 frame=void cellpadding=4 cellspacing=0>
+  <table class="reg reg-huge" id="tbl:reg-bldcnt" border=1 frame=void cellpadding=4 cellspacing=0>
     <caption class="reg">REG_BLDCNT (REG_BLDMOD) @ <code>0400:0050h</code></caption>
     <tr class="bits">
       <td>F E</td>
@@ -336,7 +336,6 @@ The `REG_BLDALPHA` and `REG_BLDY` registers hold the blending weights in the for
       <td class="rclr0">eva</td>
     </tr>
   </table>
-  <br>
   <table>
     <col class="bits" width=40>
     <col class="bf" width="8%">
@@ -376,7 +375,6 @@ The `REG_BLDALPHA` and `REG_BLDY` registers hold the blending weights in the for
       <td class="rclr2">ey</td>
     </tr>
   </table>
-  <br>
   <table>
     <col class="bits" width=40>
     <col class="bf" width="8%">
@@ -672,7 +670,7 @@ So you have one byte for each value. That's bytes as in *unsigned* chars. The co
 The possible content for the windows are backgrounds 0-3 and objects. No suprise there, right? In total, we have regions: win0, win1, winOut and winObj. `REG_WININ` (`0400:0048h`) controls win0 and win1, `REG_WINOUT` (`0400:004ah`) takes care of winOut and winObj. There's one bit for each content-type, plus one for blending, which you will need if you intend to use blending on the contents of that particular window.
 
 <div class="reg">
-  <table class="reg" id="tbl:reg-winio" border=1 frame=void cellpadding=4 cellspacing=0>
+  <table class="reg reg-huge" id="tbl:reg-winio" border=1 frame=void cellpadding=4 cellspacing=0>
     <tr class="bits">
       <th>register</th>
       <td>F E</td>

--- a/content/interrupts.md
+++ b/content/interrupts.md
@@ -361,7 +361,7 @@ Note: I said register**s**, plural! Each CPU mode has its own stack and link reg
 <br>  
 So, assembly it is then. The function below is the assembly equivalent of `irs_master_c()`. It is almost a line by line translation, although I am making use of a few features of the instruction set the compiler wont't or can't. I don't expect you to really understand everything written here, but with some imagination you should be able to follow most of it. Teaching assembly is *way* beyond the scope of this chapter, but worth the effort in my view. Tonc's [assembly chapter](asm.html) should give you the necessary information to understand most of it and shows where to go to learn more.
 
-```asm
+```armasm
     .file   "tonc_isr_master.s"
     .extern __isr_table;
 

--- a/content/regbg.md
+++ b/content/regbg.md
@@ -66,11 +66,11 @@ Both the tiles and tilemaps are stored in VRAM, which is divided into <dfn>charb
   <b>{*@tbl:cbb-sbb}</b>:
   charblock and screenblock overlap.
 </caption>
-<colgroup span=1 style="background-color:#D0D0D0;"></colgroup>
-<colgroup span=3 style="background-color:#B0B0B0;"></colgroup>
-<colgroup span=3 style="background-color:#D0D0D0;"></colgroup>
-<colgroup span=3 style="background-color:#B0B0B0;"></colgroup>
-<colgroup span=3 style="background-color:#D0D0D0;"></colgroup>
+<colgroup span=1 style="background-color:none;"></colgroup>
+<colgroup span=3 style="background-color:var(--table-alternate-bg);"></colgroup>
+<colgroup span=3 style="background-color:none;"></colgroup>
+<colgroup span=3 style="background-color:var(--table-alternate-bg);"></colgroup>
+<colgroup span=3 style="background-color:none;"></colgroup>
 
 <tbody align="left"><tr>
   <th>Memory
@@ -234,10 +234,8 @@ The description of `REG_BGxCNT` can be found below. Most of it is pretty standar
 </table>
 </div>
 
-<div class="cblock">
-<table width="100%" id="tbl:bg-size">
-<tr align="center">
-<td>
+<div class="cblock" id="tbl:bg-size">
+<div style="display: inline-block">
   <table id="tbl-reg-size" border=1 cellpadding=2  cellspacing=0>
   <caption align="bottom">
     <b>{*@tbl:bg-size}a</b>: regular bg sizes
@@ -251,7 +249,8 @@ The description of `REG_BGxCNT` can be found below. Most of it is pretty standar
     <tr><td> 11   <td><code>BG_REG_64x64</code> <td> 64×64 <td> 512×512 
   </tbody>
   </table>
-<td>
+</div>
+<div style="display: inline-block">
   <table id="tbl-aff-size" border=1 cellpadding=2 cellspacing=0>
   <caption align="bottom">
     <b>{*@tbl:bg-size}b</b>: affine bg sizes
@@ -265,8 +264,8 @@ The description of `REG_BGxCNT` can be found below. Most of it is pretty standar
     <tr><td> 11   <td><code>BG_AFF_128x128</code><td>128×128 <td>1024×1024
   </tbody>
   </table>
-</table>
-</div><br>
+</div>
+</div>
 
 Each background has two 16-bit scrolling registers to offset the rendering (`REG_BGxHOFS` and `REG_BGxVOFS`). There are a number of interesting points about these. First, because regular backgrounds wrap around, the values are essentially modulo *mapsize*. This is not really relevant at the moment, but you can use this to your benefit once you get to more advanced tilemaps. Second, these registers are **write-only**! This is a little annoying, as it means that you can't update the position by simply doing `REG_BG0HOFS++` and the like.
 
@@ -745,6 +744,7 @@ The second demo, *sbb_reg*, uses a 64×64t background to indicate how multiple s
 
 
 <div id="cd-demo-sbb">
+
 ```c
 #include "toolbox.h"
 #include "input.h"
@@ -1048,7 +1048,7 @@ I intend to use tonclib in a number of later demos. In particular, the memory ma
 <div class="note">
 <div class="nhgood">
 
-Better copy and fill routines: `memcpy16`/`32` and `memset16`/`32`
+Better copy and fill routines: memcpy16/32 and memset16/32
 
 </div>
 

--- a/content/regobj.md
+++ b/content/regobj.md
@@ -194,9 +194,11 @@ There are a few interesting things about these structures. First, you see a lot 
 </div>
 
 <div class="note">
+
 <div class="nhgood">
 Force alignment on OBJ_ATTRs
 </div>
+
 As of devkitARM r19, there are new rules on struct alignments, which means that structs may not always be word aligned, and in the case of `OBJ_ATTR` structs (and others), means that `struct` copies like the one in `oam_update()` later on, will not only be slow, they may actually break. For that reason, I will force word-alignment on many of my structs with `ALIGN4`, which is a macro for `__attribute__((aligned(4)))`. For more on this, see the section on [data alignment](bitmaps.html#ssec-data-align).
 </div>
 
@@ -358,10 +360,10 @@ I'll say it here too: `attr0` contains *y*, `attr1` contains *x*. Note that bits
 This attribute tells the GBA which tiles to display and its background priority. If it's a 4bpp sprite, this is also the place to say what sub-palette should be used.
 
 <div class="reg">
-<table class="reg" id="tbl:oe-attr2"
+<table class="reg" id="tbl-oe-attr2"
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
-  {*@tbl:oe-attr2}: <code>OBJ_ATTR.attr2</code>
+  <code>OBJ_ATTR.attr2</code>
 </caption>
 <tr class="bits">
 	<td>F E D C<td>B A<td>9 8 7 6 5 4 3 2 1 0
@@ -379,19 +381,19 @@ This attribute tells the GBA which tiles to display and its background priority.
 <tbody valign="top">
 <tr class="bg0">	
   <td>0-9<td class="rclr0">TID
-  <td><code>ATTR2_ID#</code>
+  <td>ATTR2_ID#
   <td>Base <b>tile index</b> of sprite. Note that in bitmap modes,
     this must be 512 or higher.
 <tr class="bg1">	
   <td>A-B<td class="rclr2">Pr
-  <td><code>ATTR2_PRIO#</code>
+  <td>ATTR2_PRIO#
   <td><b>Priority</b>. Higher priorities are drawn first (and therefore 
     can be covered by later sprites and backgrounds). Sprites cover 
     backgrounds of the same priority, and for sprites of the 
     same priority, the higher <code>OBJ_ATTR</code>s are drawn first.
 <tr class="bg0">	
   <td>C-F<td class="rclr1">PB
-  <td><code>ATTR2_PALBANK#</code>
+  <td>ATTR2_PALBANK#
   <td><b>Palette bank</b> to use when in 16-color mode. Has no effect if
 	the color mode flag (<code>attr0</code>{C}) is set.
 </tbody>
@@ -497,7 +499,7 @@ Finally, what I call my build macros. These piece together the various bit-flags
 #define ATTR1_BUILD_A(x, size, aff_id)               \
 ( ((x)&511) | (((aff_id)&31)<<9) | (((size)&3)<<14) )
 
-Attribute 2
+// Attribute 2
 #define ATTR2_BUILD(id, pbank, prio)                 \
 ( ((id)&0x3FF) | (((pbank)&15)<<12) | (((prio)&3)<<10) )
 ```

--- a/content/sndsqr.md
+++ b/content/sndsqr.md
@@ -895,7 +895,7 @@ R(f) = 2048 - \frac{2^{17}}{f}
 Both square-wave generators have registers `REG_SNDxCNT` for envelope/length/duty control and `REG_SNDxFREQ` for frequency control. Sound 1 also has sweep control in the form of `REG_SND1SWEEP`. Look in {@tbl:snd-names} for the traditional names; note that in traditional nomenclature the suffixes for control and frequency are *different* for channels 1 and 2, even though they have exactly the same function.
 
 <div class="reg">
-<table class="reg" id="tbl-reg-snd1cnt"
+<table class="reg" id="tbl-reg-snd1cnt" width=420
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
 <span class="nobr">
@@ -1014,7 +1014,7 @@ A_m = \frac{2}{\pi} \cdot \frac{sin({\pi}Dm)}{m}
 Some more on the duty cycle. Remember we've done a Fourier analysis of the square wave so we could determine the frequencies in it. Apart from the **base frequency**, there are also **overtones** of frequencies *m·f*. The spectrum (see {@fig:sqrf}) gives the amplitudes of all these frequencies. Note that even though the figure has lines, only integral values of *m* are allowed. The base frequency at *m*=1 has the highest significance and the rest falls off with 1/*m*. The interesting part is when the sine comes into play: whenever *m·D* is an integer, that component vanishes! With a fractional duty number –like the ones we have– this happens every time *m* is equal to the denominator. For the 50% duty, every second overtone disappears, leaving a fairly smooth tone; for 12.5%, only every eighth vanishes and the result is indeed a noisier sound. Note that for *both* ¼ and ¾ duties every fourth vanishes so that they should be indistinguishable. I was a little surprised about this result, but sure enough, when I checked they really did sound the same to me.
 
 <div class="reg">
-<table class="reg" id="tbl-reg-snd1freq"
+<table class="reg" id="tbl-reg-snd1freq" width=420
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
 <span class="nobr">
@@ -1068,7 +1068,7 @@ Some more on the duty cycle. Remember we've done a Fourier analysis of the squar
 </div><br>
 
 <div class="reg">
-<table class="reg" id="tbl-reg-snd1sweep"
+<table class="reg" id="tbl-reg-snd1sweep" width=420
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
   REG_SND1SWEEP (SOUND1CNT_L / SG10_L) @ <code>0400:0060h</code>

--- a/content/swi.md
+++ b/content/swi.md
@@ -189,7 +189,6 @@ The source address points to an array of `AFF_SRC` structs (also known as `ObjAf
   </mstyle>
 </math>
 
-<br>  
 By now you should know what this does: it scales horizontally by 1/*s*<sub>x</sub>, vertically by 1/*s*<sub>y</sub> followed by a counter-clockwise rotation by *α*. `ObjAffineSet()` does almost exactly what `obj_aff_rotscale()` and `bg_aff_rotscale()` do, except that `ObjAffineSet()` can also set multiple matrices at once.
 
 The source data is kept in `ObjAffineSource` (i.e., `AFF_SRC`) structs. Now, as the routine sets affine matrices, you might think that the destinations are either `OBJ_AFFINE` or `ObjAffineDest` structs. However, you'd be wrong. Well, partially anyway. The problem is that the destination always points to a *p*<sub>a</sub>-element, which is not necessarily the first element in struct. You *will* make the mistake of simply supplying an `OBJ_AFFINE` pointer when you try to use it to fill those. Don't say I didn't warn you.
@@ -228,7 +227,7 @@ typedef struct OBJ_AFFINE
 
 You might think this whole discussion was rather pointless since you can't access the registers and the `swi` instruction unless you use assembly, which will be pretty tough, right? Well, no, yes and no. The necessary assembly steps for BIOS calls are actually rather simple, and are given below.
 
-```asm
+```armasm
 @ In tonc_bios.s
 
 @ at top of your file

--- a/content/text.md
+++ b/content/text.md
@@ -1,9 +1,7 @@
----
 Title: Text Systems
 Date: 2005-05-19
 Modified: 2013-03-14
 Authors: Cearn
----
 
 # 19. Text systems {#ch-}
 
@@ -222,7 +220,7 @@ In case it's still a bit hazy, @fig:img-fontpack shows how the ‘F’ is packed
 </style>
 
 <div class="cblock">
-<div class="cpt" style="width:750px;">
+<div style="width:750px;">
 <table id="fig:img-fontpack"
   border=0 cellpadding=4 cellspacing=0 style="table-layout:fixed; width:100%; page-break-inside: avoid;">
   <tbody align="center">
@@ -238,7 +236,7 @@ In case it's still a bit hazy, @fig:img-fontpack shows how the ‘F’ is packed
     <td>
     <img src="img/font_pack.png" alt="pixels" style="width: 160px;">
     <td> <!-- bits -->
-    <table class="reg" cellpadding=1 cellspacing=0>
+    <table cellpadding=1 cellspacing=0>
       <tr>
         <td class="bdrLL">&nbsp;
         <th> 7 <th> 6 <th> 5 <th> 4 <th> 3 <th> 2 <th> 1 <th> 0
@@ -1131,54 +1129,54 @@ for(ii=0; ii<96*8; ii++)
 
 These six statements set up the three fonts, complete with shading and opacity. The first one sets up the standard font, in charblock 0, screenblock 31, pal-bank 1 and using `0x0E` for the bit-unpacking offset, so that the text color is at `0x1F`. We've seen the same thing with the object text.
 
-<div class="cpt_fr" style="width:400px; margin: 0px auto;">
+<div class="cpt_fr" style="width:340px; margin: 0px auto;">
 <center>
 <table id="tbl:bupshade"
     cellpadding=2 cellspacing=0 bgcolor=#E0E0E0 style="table-layout: fixed; width: 100%;">
 <caption align="bottom">
-  <b>@tbl:bupshade</b>: 
+  <b>*@tbl:bupshade</b>: 
   bit-unpacking with with base <code>0xEE</code>.
 </caption>
 <tbody align="center">
   <tr>
-    <td class="bdrLL" rowspan=9>&nbsp;
+    <td rowspan=9>&nbsp;
     <th>bit 
-    <th class="bdrL">val
-    <td class="bdrRR" rowspan=9>&nbsp;
-    <td class="bdrLL">&nbsp;
+    <th>val
+    <td rowspan=9>&nbsp;
+    <td>&nbsp;
     <th> 7 <th> 6 <th> 5 <th> 4 <th> 3 <th> 2 <th> 1 <th> 0
-    <td class="bdrRR">&nbsp;
+    <td>&nbsp;
   <tr>
-    <th>0	<td class="bdrL"> 0
-    <td class="bdrLL" rowspan=8>&nbsp;
+    <th>0	<td> 0
+    <td rowspan=8>&nbsp;
     <td> . <td> . <td> . <td> . <td> . <td> . <td> . <td> 0
-    <td class="bdrRR" rowspan=8>&nbsp;
+    <td rowspan=8>&nbsp;
   <tr>
-    <th> 1	<td class="bdrL"> 1
+    <th> 1	<td> 1
     <td> . <td> . <td> . <td> . <td> . <td> E <td> F <td> .
   <tr>
-    <th> 2	<td class="bdrL"> 1
+    <th> 2	<td> 1
     <td> . <td> . <td> . <td> . <td> E <td> F <td> . <td> .
   <tr>
-    <th> 3	<td class="bdrL"> 1
+    <th> 3	<td> 1
     <td> . <td> . <td> . <td> E <td> F <td> . <td> . <td> .
   <tr>
-    <th> 4	<td class="bdrL"> 0
+    <th> 4	<td> 0
     <td> . <td> . <td> . <td> 0 <td> . <td> . <td> . <td> .
   <tr>
-    <th> 5	<td class="bdrL"> 0
+    <th> 5	<td> 0
     <td> . <td> . <td> 0 <td> . <td> . <td> . <td> . <td> .
   <tr>
-    <th> 6	<td class="bdrL"> 1
+    <th> 6	<td> 1
     <td> E <td> F <td> . <td> . <td> . <td> . <td> . <td> .
   <tr>
-    <th> 7	<td class="bdrL"> 0
+    <th> 7	<td> 0
     <td> 0 <td> . <td> . <td> . <td> . <td> . <td> . <td> .
 <tr>
   <td colspan=4> OR: 
-    <td class="bdrLL">&nbsp;
+    <td>&nbsp;
     <th> E <th> F <th> 0 <th> E <th> F <th> F <th> F <th> 0
-    <td class="bdrRR">&nbsp;
+    <td>&nbsp;
 </tbody>
 </table>
 </center>
@@ -1391,17 +1389,20 @@ INLINE u32 profile_stop()
 </table>
 </div>
 
-@fig:img-txt-se2 shows the timing results, as run in VisualBoy Advance and no\$gba. Note that they are not quite the same. So you do what you should always do when two opinions differ: get a third one. In this case, I'll use the only one that really matters, namely hardware. You can see a comparison of the three in @tbl:txt-se2, which will tell you that no\$gba is very accurate in its timing, but VBA not so much. I guess you can still use it to get an estimate or relative timings, but true accuracy will not be found there. For that you need hardware or no\$gba.
+*@fig:img-txt-se2 shows the timing results, as run in VisualBoy Advance and no\$gba. Note that they are not quite the same. So you do what you should always do when two opinions differ: get a third one. In this case, I'll use the only one that really matters, namely hardware. You can see a comparison of the three in @tbl:txt-se2, which will tell you that no\$gba is very accurate in its timing, but VBA not so much. I guess you can still use it to get an estimate or relative timings, but true accuracy will not be found there. For that you need hardware or no\$gba.
 
 About the numbers themselves. The spread is about a factor 9, which is quite a lot. None of the techniques shown here are particularly hard to understand, and data copying is something that you could spend a lot of time doing, so might as well take advantage of the faster ones from the get go.
 
 Most of the tutorial code and probably a lot of demo code you can find out there uses the u16-array method of copying; presumably because byte-copies are unavailable for certain sections. But as you can see, **u16 copies are more than twice as slow as u32 copies**! Granted, it is not the slowest method of copying data, but not by much (using u16 loop variables –also a common occurence– would be slower by about 20%; try it and you'll see). The GBA is a 32-bit machine. It _likes_ 32-bit data, and its instruction sets are better at dealing with 32-bit chunks. Let go of the u16 fetish you may have picked up elsewhere. Use word-sized data if you can, the others only if you have to. That said, do watch your [data alignment](bitmaps.html#ssec-data-align)! u8 or u16 arrays aren't always word-aligned, which will cause trouble with casting.
 
-<!-- This should be styled as NOTE --> 
-> **GCC and waitstates vs timing results**
->
-> Giving exact timing results is tricky due to a number of factors. First, on the hardware side there are different memory sections with different wait states that complicate things unless you sit down, read the assembly and add up the cycle-counts of the instructions. This is a horrible job, trust me. The second problem is that GCC hasn't reached the theoretical optimum for this code yet, so the results tend to vary with new releases. What you see above is a good indication, but your mileage may vary.
+<div class="note">
+<div class="nhcare">
+GCC and waitstates vs timing results
+</div>
+ 
+Giving exact timing results is tricky due to a number of factors. First, on the hardware side there are different memory sections with different wait states that complicate things unless you sit down, read the assembly and add up the cycle-counts of the instructions. This is a horrible job, trust me. The second problem is that GCC hasn't reached the theoretical optimum for this code yet, so the results tend to vary with new releases. What you see above is a good indication, but your mileage may vary.
 
+</div>
 
 There are a number of fast ways of copying large chunks of data. Faster than writing your own simple loop that is. Common ones are the standard `memcpy()`, which is available for any platform, and two methods that are GBA specific: the `CpuFastSet()` BIOS call (or my own version `memcpy32()` and DMA. The first two _require_ word-alignment; DMA merely works better with it. The performance of `memcpy()` is actually not too shabby, and the fact that it's available everywhere means that it's a good place to start. The others are faster, but come at a cost: `memcpy32()` is hand written assembly; `CpuFastSet()` requires a word-count divisible by 8, and DMA locks up the CPU, which can interfere with interrupts. You would do well to remember these things when you find you need a little more speed.
 

--- a/content/video.md
+++ b/content/video.md
@@ -82,9 +82,7 @@ Finally, we have sprites. Sprites are small (8x8 to 64x64 pixels) graphical obje
 <div class="note">
 
 <div class="nhgood">
-
 Prefer tile modes over bitmap modes
-
 </div>
 
 In almost all types of games, the tile modes will be more suitable. Most other tutorials focus on bitmap modes, but that's only because they are easier on beginners, not because of their practical value for games. The vast majority of commercial games use tile modes; that should tell you something.
@@ -247,7 +245,7 @@ Now the other two registers I mentioned, `REG_DISPSTAT` and `REG_VCOUNT`. The la
 </div><br>
 
 <div class="reg">
-<table class="reg" id="tbl:reg-vcount"
+<table class="reg" id="tbl:reg-vcount" width="320"
   border=1 frame=void cellPadding=4 cellSpacing=0>
 <caption class="reg">
   REG_VCOUNT @ <code>0400:0006h</code> (read-only)
@@ -283,7 +281,7 @@ void vid_vsync()
 {    while(REG_VCOUNT < 160);   }
 ```
 
-Unfortunately, there are a few problems with this code. First of all, if you're simply doing an empty `while` loop to wait for 160, the compiler may try to get smart, notice that the loop doesn't change `REG_VCOUNT` and put its value in a register for easy reference. Since there is a good chance that that value will be below 160 at some point, you have a nice little infinite loop on your hand. To prevent this, use the keyword `volatile`{.keyw} (see `regs.h`). Second, in small demos simply waiting for the VBlank isn't enough; you may still be in that VBlank when you call `vid_sync()` again, which will be blazed through immediately. That does not sync to 60 fps. To do this, you first have to wait until the *next* VDraw. This makes our `vid_sync` look a little like this:
+Unfortunately, there are a few problems with this code. First of all, if you're simply doing an empty `while` loop to wait for 160, the compiler may try to get smart, notice that the loop doesn't change `REG_VCOUNT` and put its value in a register for easy reference. Since there is a good chance that that value will be below 160 at some point, you have a nice little infinite loop on your hand. To prevent this, use the keyword `volatile` (see `regs.h`). Second, in small demos simply waiting for the VBlank isn't enough; you may still be in that VBlank when you call `vid_sync()` again, which will be blazed through immediately. That does not sync to 60 fps. To do this, you first have to wait until the *next* VDraw. This makes our `vid_sync` look a little like this:
 
 ```c
 #define REG_VCOUNT *(vu16*)0x04000006
@@ -295,6 +293,6 @@ void vid_vsync()
 }
 ```
 
-This will always wait until the start of the next VBlank occurs. And `REG_VCOUNT` is now `volatile`{.keyw} (the “`vu16`” is `typedef`ed as a <u>v</u>olatile <u>u</u>nsigned (<u>16</u>bit) short. I'll be using a lot of this kind of shorthand, so get used to it). That's one way to do it. Another is checking the last bit in the display status register, `REG_DISPSTAT`\{0\}.
+This will always wait until the start of the next VBlank occurs. And `REG_VCOUNT` is now `volatile` (the “`vu16`” is `typedef`ed as a <u>v</u>olatile <u>u</u>nsigned (<u>16</u>bit) short. I'll be using a lot of this kind of shorthand, so get used to it). That's one way to do it. Another is checking the last bit in the display status register, `REG_DISPSTAT`\{0\}.
 <br>  
 So we're done here, right? Errm ... no, not exactly. While it's true that you now have an easy way to vsync, it's also a very poor one. While you're in the while loop, you're still burning CPU cycles. Which, of course, costs battery power. And since you're doing absolutely nothing inside that while-loop, you're not just using it, you're actually wasting battery power. Moreover, since you will probably make only small games at first, you'll be wasting a *LOT* of battery power. The recommended way to vsync is putting the CPU in low-power mode when you're done and then use interrupts to bring it back to life again. You can read about the procedure [here](swi.html#sec-vsync2), but since you have to know how to use [interrupts](interrupts.html) and [BIOS calls](swi.html), you might want to wait a while.

--- a/theme/css/general.css
+++ b/theme/css/general.css
@@ -1,0 +1,368 @@
+/* Base styles and content styles */
+
+@import 'variables.css';
+
+:root {
+    /* Browser default font-size is 16px, this way 1 rem = 10px */
+    font-size: 62.5%;
+    color-scheme: var(--color-scheme);
+}
+
+html {
+    font-family: "Open Sans", sans-serif;
+    color: var(--fg);
+    background-color: var(--bg);
+    text-size-adjust: none;
+    -webkit-text-size-adjust: none;
+}
+
+body {
+    margin: 0;
+    font-size: 1.6rem;
+    overflow-x: hidden;
+}
+
+code {
+    font-family: var(--mono-font) !important;
+    font-size: var(--code-font-size);
+    direction: ltr !important;
+}
+
+/* make long words/inline code not x overflow */
+main {
+    overflow-wrap: break-word;
+}
+
+/* make wide tables scroll if they overflow */
+.table-wrapper {
+    overflow-x: auto;
+}
+
+/* Don't change font size in headers. */
+h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
+    font-size: unset;
+}
+
+.left { float: left; }
+.right { float: right; }
+.boring { opacity: 0.6; }
+.hide-boring .boring { display: none; }
+.hidden { display: none !important; }
+
+h2, h3 { margin-block-start: 2.5em; }
+h4, h5 { margin-block-start: 2em; }
+
+.header + .header h3,
+.header + .header h4,
+.header + .header h5 {
+    margin-block-start: 1em;
+}
+
+h1:target::before,
+h2:target::before,
+h3:target::before,
+h4:target::before,
+h5:target::before,
+h6:target::before {
+    display: inline-block;
+    content: "»";
+    margin-inline-start: -30px;
+    width: 30px;
+}
+
+/* This is broken on Safari as of version 14, but is fixed
+   in Safari Technology Preview 117 which I think will be Safari 14.2.
+   https://bugs.webkit.org/show_bug.cgi?id=218076
+*/
+:target {
+    /* Safari does not support logical properties */
+    scroll-margin-top: calc(var(--menu-bar-height) + 0.5em);
+}
+
+.page {
+    outline: 0;
+    padding: 0 var(--page-padding);
+    margin-block-start: calc(0px - var(--menu-bar-height)); /* Compensate for the #menu-bar-hover-placeholder */
+}
+.page-wrapper {
+    box-sizing: border-box;
+    background-color: var(--bg);
+}
+.no-js .page-wrapper,
+.js:not(.sidebar-resizing) .page-wrapper {
+    transition: margin-left 0.3s ease, transform 0.3s ease; /* Animation: slide away */
+}
+[dir=rtl] .js:not(.sidebar-resizing) .page-wrapper {
+    transition: margin-right 0.3s ease, transform 0.3s ease; /* Animation: slide away */
+}
+
+.content {
+    overflow-y: auto;
+    padding: 0 5px 50px 5px;
+}
+.content main {
+    margin-inline-start: auto;
+    margin-inline-end: auto;
+    max-width: var(--content-max-width);
+}
+.content p { line-height: 1.45em; }
+.content ol { line-height: 1.45em; }
+.content ul { line-height: 1.45em; }
+.content a { text-decoration: none; }
+.content a:hover { text-decoration: underline; }
+.content img, .content video { max-width: 100%; }
+.content .header:link,
+.content .header:visited {
+    color: var(--fg);
+}
+.content .header:link,
+.content .header:visited:hover {
+    text-decoration: none;
+}
+
+table {
+    margin: 0 auto;
+    border-collapse: collapse;
+}
+table td {
+    padding: 3px 16px;
+    border: 1px var(--table-border-color) solid;
+}
+table thead {
+    background: var(--table-header-bg);
+}
+table thead td {
+    font-weight: 700;
+    border: none;
+}
+table thead th {
+    padding: 3px 16px;
+}
+table thead tr {
+    border: 1px var(--table-header-bg) solid;
+}
+/* Alternate background colors for rows */
+table tbody tr:nth-child(2n) {
+    background: var(--table-alternate-bg);
+}
+
+
+blockquote {
+    margin: 20px 0;
+    padding: 0 20px;
+    color: var(--fg);
+    background-color: var(--quote-bg);
+    border-block-start: .1em solid var(--quote-border);
+    border-block-end: .1em solid var(--quote-border);
+}
+
+.warning {
+    margin: 20px;
+    padding: 0 20px;
+    border-inline-start: 2px solid var(--warning-border);
+}
+
+.warning:before {
+    position: absolute;
+    width: 3rem;
+    height: 3rem;
+    margin-inline-start: calc(-1.5rem - 21px);
+    content: "ⓘ";
+    text-align: center;
+    background-color: var(--bg);
+    color: var(--warning-border);
+    font-weight: bold;
+    font-size: 2rem;
+}
+
+blockquote .warning:before {
+    background-color: var(--quote-bg);
+}
+
+kbd {
+    background-color: var(--table-border-color);
+    border-radius: 4px;
+    border: solid 1px var(--theme-popup-border);
+    box-shadow: inset 0 -1px 0 var(--theme-hover);
+    display: inline-block;
+    font-size: var(--code-font-size);
+    font-family: var(--mono-font);
+    line-height: 10px;
+    padding: 4px 5px;
+    vertical-align: middle;
+}
+
+:not(.footnote-definition) + .footnote-definition,
+.footnote-definition + :not(.footnote-definition) {
+    margin-block-start: 2em;
+}
+.footnote-definition {
+    font-size: 0.9em;
+    margin: 0.5em 0;
+}
+.footnote-definition p {
+    display: inline;
+}
+
+.tooltiptext {
+    position: absolute;
+    visibility: hidden;
+    color: #fff;
+    background-color: #333;
+    transform: translateX(-50%); /* Center by moving tooltip 50% of its width left */
+    left: -8px; /* Half of the width of the icon */
+    top: -35px;
+    font-size: 0.8em;
+    text-align: center;
+    border-radius: 6px;
+    padding: 5px 8px;
+    margin: 5px;
+    z-index: 1000;
+}
+.tooltipped .tooltiptext {
+    visibility: visible;
+}
+
+.chapter li.part-title {
+    color: var(--sidebar-fg);
+    margin: 5px 0px;
+    font-weight: bold;
+}
+
+.result-no-output {
+    font-style: italic;
+}
+
+/* -------------------------------------------------------------- */
+
+/* Style sheet for TONC */
+
+div.note {
+	width: 94%;
+	margin: 0.7em auto;
+	/* padding: 6px 12px 1px 16px; */
+  padding: 4px 10px;
+	page-break-inside: avoid;
+  background-color: var(--table-alternate-bg);
+}
+div.note p, div.note ul {
+  margin: 6px 0;
+}
+div.note ul {
+  padding-left: 20px;
+}
+
+div.nh, div.nhgood, div.nhbad, div.nhcare {
+  font-weight: bold;
+  margin-top: 5px;
+  /* margin-bottom: -0.5em; */
+  padding-bottom: 3px;
+  border-bottom: 1px solid var(--quote-border);
+}
+
+/* TODO: can we use colours from the syntax highlighting style instead? */
+
+div.nhbad, span.rem, .ack {
+  color: #ec1256;
+}
+div.nhgood {
+  color: #1ec36d;
+}
+div.nhcare {
+  color: #e88f42;
+}
+
+div.endtag	{ text-align:right; font-size: 70%;	}
+
+/* --- picture+caption frames --- */
+div.cpt, div.cpt_fl, div.cpt_fr {
+	margin: .5em;		padding: 4px;
+	border: 1px var(--table-border-color) solid;
+  background-color: var(--table-alternate-bg);
+	font-size: 80%; 
+	page-break-inside: avoid;
+}
+
+div.cpt_fl	{ float:left;	}
+div.cpt_fr	{ float:right; }
+
+/* Margins inside tables work differently. */
+td div.cpt, td div.dpt_fl, td div.cpt_fr {
+	margin: 0;
+}
+
+.cpt p, .cpt_fl p, .cpt_fr p {
+  margin: 0.5em 0;
+}
+
+/* --- table block styles --- */
+/* yes, table and caption forms are required */
+
+div.reg			{	margin: 8px auto;	text-align:center;	width: 94%;	}
+div.reg table	{	margin: 1px auto; margin-bottom: 12px;	text-align:left;	}
+div.reg caption	{	margin: 0px auto;	text-align:left;	}
+
+div.cblock			{	margin: 6px auto;	text-align:center;	}
+div.cblock div		{	margin: 2px auto;	text-align:left;	}
+div.cblock table	{	margin: 2px auto;	text-align:left;	}
+div.cblock caption	{	margin: 0px auto;	text-align:left;	}
+
+/* div.lblock			{	margin: 6px 3em;	}
+div.lblock table	{	margin: 2px 0;		} */
+
+div.cblock div.cpt	{ margin: 0.5em auto; }
+
+/* Fix oversight in the mdBook styles? */
+table, table th {
+  border: 1px var(--table-border-color) solid;
+}
+
+/* Gotta make register diagram table cells smaller so they fit on the page. */
+table.reg th, table.reg td {
+  padding: 3px 13px;
+}
+/* But some are too big even still. */
+table.reg-huge th, table.reg-huge td {
+  padding: 3px 7px;
+}
+
+/* === Table styles === */
+
+td.fill, th.fill	{ width: 16px; }
+
+/* --- reg table --- */
+table.reg {
+	font: 90% var(--mono-font);
+	page-break-inside: avoid;
+}
+caption.reg			{ caption-side:top; }
+
+caption[align="bottom"], div.cblock caption[align="bottom"] {
+  margin-top: 6px;
+}
+
+tr.bits, tr.bf, col.bits, col.bf, col.def { text-align:center; }
+col.bits, col.bf, col.def {	vertical-align:top; 	}
+tr.bits, col.bits		{	font: 90% var(--mono-font);	}
+tr.bf, col.bf			{	font-weight:bold;			}
+col.def					{	font: 90% var(--mono-font);	}
+
+/* read only, write only */
+.rof	{ text-decoration:overline;  color: #f22;  }
+.wof	{ text-decoration:underline; color: #44f; }
+
+/* reg colors */
+.rclr0 { color: #ef0d4b; }
+.rclr1 { color: #41adff; }
+.rclr2 { color: #45e774; }
+.rclr3 { color: #d948d9; }
+.rclr4 { color: #f9663e; }
+.rclr5 { color: #d09a4c; }
+.rclr6 { color: #e7849b; }
+.rclr7 { color: #dce24b; }
+.rclr8	{ color:teal;		}
+.rclr9	{ color:gray;		}
+
+font[color="blue"] { color: #43a8e6; }
+font[color="green"] { color: #45e774; }
+font[color="red"] { color: #ef0d4b; }


### PR DESCRIPTION
This PR cleans up all the register diagrams, fixes the messy white borders on tables, and adds the missing styling for `note` sections