### PR TITLE
Reduce monospace font size + clean up register diagram captions

### DIFF
--- a/content/asm.md
+++ b/content/asm.md
@@ -1647,7 +1647,7 @@ Before I show the bits, I should point out that `add` (and in fact all data inst
 <div class="reg">
   <table class="reg" id="tbl:arm-add" border=1 frame=void cellpadding=2 cellspacing=0>
     <caption class="reg">
-      <b>{*@tbl:arm-add}</b>: The <code>add</code> instruction(s)
+      <b>{*@tbl:arm-add}</b>: The add instruction(s)
     </caption>
     <colgroup>
       <col style="width: 30%;">

--- a/content/dma.md
+++ b/content/dma.md
@@ -35,7 +35,7 @@ The use of the source and destination registers should be obvious. The control r
 <table class="reg reg-huge" id="tbl:reg-dmaxcnt"
   border=1 frame=void cellPadding=4 cellSpacing=0>
 <caption class="reg">
-  REG_DMAxCNT @ <code>0400:00B8</code>+12<i>x</i>
+  REG_DMAxCNT @ 0400:00B8+12<i>x</i>
 </caption>
 <tr class="bits">
 	<td>1F<td>1E<td>1D 1C<td>1B<td>1A<td>19<td>18 17

--- a/content/gfx.md
+++ b/content/gfx.md
@@ -21,7 +21,7 @@ To use mosaic you must do two things. First, you need to enable mosaic. For indi
 
 <div class="reg">
   <table class="reg" id="tbl:reg-mosaic" border=1 frame=void cellpadding=4 cellspacing=0>
-    <caption class="reg">REG_MOSAIC @ <code>0400:004Ch</code></caption>
+    <caption class="reg">REG_MOSAIC @ 0400:004Ch</caption>
     <tr class="bits">
       <td>F E D C</td>
       <td>B A 9 8</td>
@@ -237,7 +237,7 @@ Backgrounds are always enabled for blending. To enable sprite-blending, set `OBJ
 
 <div class="reg">
   <table class="reg reg-huge" id="tbl:reg-bldcnt" border=1 frame=void cellpadding=4 cellspacing=0>
-    <caption class="reg">REG_BLDCNT (REG_BLDMOD) @ <code>0400:0050h</code></caption>
+    <caption class="reg">REG_BLDCNT (REG_BLDMOD) @ 0400:0050h</caption>
     <tr class="bits">
       <td>F E</td>
       <td>D</td>
@@ -317,7 +317,7 @@ The `REG_BLDALPHA` and `REG_BLDY` registers hold the blending weights in the for
 
 <div class="reg">
   <table class="reg" id="tbl:reg-bldalpha" border=1 frame=void cellPadding=4 cellSpacing=0>
-    <caption class="reg">REG_BLDALPHA (REG_COLEV) @ <code>0400:0052h</code></caption>
+    <caption class="reg">REG_BLDALPHA (REG_COLEV) @ 0400:0052h</caption>
     <tr class="bits">
       <td>F E D</td>
       <td>C B A 9 8</td>
@@ -360,7 +360,7 @@ The `REG_BLDALPHA` and `REG_BLDY` registers hold the blending weights in the for
 <br>
 <div class="reg">
   <table class="reg" id="tbl:reg-bldy" border=1 frame=void cellpadding=4 cellspacing=0>
-    <caption class="reg">REG_BLDY (REG_COLEY) @ <code>0400:0054h</code></caption>
+    <caption class="reg">REG_BLDY (REG_COLEY) @ 0400:0054h</caption>
     <tr class="bits">
       <td>F E D C B A 9 8 7 6 5</td>
       <td>4 3 2 1 0</td>
@@ -598,7 +598,7 @@ Both win0 and win1 have 2 registers that define their boundaries. In order these
 
 <div class="reg">
   <table class="reg" id="tbl:reg-winxy" border=1 frame=void cellPadding=4 cellSpacing=0>
-    <caption class="reg">REG_WINxH and REG_WINxV @ <code>0400:0040-0400:0047h</code></caption>
+    <caption class="reg">REG_WINxH and REG_WINxV @ 0400:0040-0400:0047h</caption>
     <tr class="bits">
       <th>reg</th>
       <td>F E D C B A 9 8</td>

--- a/content/interrupts.md
+++ b/content/interrupts.md
@@ -20,7 +20,7 @@ Apart from setting the bits in `REG_IE`, you also need to set a bit in other reg
 <table class="reg" id="tbl:reg-ie"
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
-  REG_IE @ <code>0400:0200</code> and REG_IF @ <code>0400:0202</code>
+  REG_IE @ 0400:0200 and REG_IF @ 0400:0202
 </caption>
 <tr class="bits">
   <td>F E<td>D<td>C<td>B A 9 8<td>7<td>6 5 4 3<td>2<td>1<td>0

--- a/content/intro.md
+++ b/content/intro.md
@@ -132,7 +132,7 @@ Every time I introduce a register I will give an overview of the bits like this:
 <table class="reg"
   border=1 frame=void cellPadding=4 cellSpacing=0>
 <caption class="reg">
-  REG_DISPSTAT @ <code>0400:0004h</code>
+  REG_DISPSTAT @ 0400:0004h
 </caption>
 <tr class="bits">
   <td>F E D C B A 9 8

--- a/content/keys.md
+++ b/content/keys.md
@@ -14,7 +14,7 @@ As said, the GBA has ten buttons, often referred to as keys. Their states can be
 
 <div class="reg">
   <table class="reg" id="tbl-reg-keys" border=1 frame=void cellpadding=4 cellspacing=0>
-    <caption class="reg">REG_KEYINPUT (REG_P1) @ <code>0400:0130h</code></caption>
+    <caption class="reg">REG_KEYINPUT @ 0400:0130h</caption>
     <tr class="bits rof">
       <td>F E D C B A</td>
       <td>9</td>
@@ -65,7 +65,7 @@ Just about everything you will ever need in terms of key-handling can be done wi
 <br>
 <div class="reg">
   <table class="reg" id="tbl-reg-keycnt" border=1 frame=void cellpadding=4 cellspacing=0>
-    <caption class="reg">REG_KEYCNT (REG_P1CNT) @ <code>0400:0132h</code></caption>
+    <caption class="reg">REG_KEYCNT @ 0400:0132h</caption>
     <tr class="bits">
       <td>F</td>
       <td>E</td>

--- a/content/regbg.md
+++ b/content/regbg.md
@@ -168,7 +168,7 @@ The description of `REG_BGxCNT` can be found below. Most of it is pretty standar
 <table class="reg" id="tbl-reg-bgxcnt"
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
-  REG_BGxCNT @ <code>0400:0008</code> + 2<i>x</i>
+  REG_BGxCNT @ 0400:0008 + 2<i>x</i>
 </caption>
 <tr class="bits">
 	<td>F E<td>D<td> C B A 9 8

--- a/content/regobj.md
+++ b/content/regobj.md
@@ -206,7 +206,7 @@ The first attribute controls a great deal, but the most important parts are for 
 <table class="reg" id="tbl-oe-attr0"
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
-  <code>OBJ_ATTR.attr0</code>
+  OBJ_ATTR.attr0
 </caption>
 <tr class="bits">
 	<td>F E<td>D<td>C<td>B A<td>9 8 <td>7 6 5 4 3 2 1 0
@@ -297,7 +297,7 @@ The primary parts of this attribute are the *x* coordinate and the size of the s
 <table class="reg" id="tbl-oe-attr1"
   border=1 frame=void cellPadding=4 cellSpacing=0>
 <caption class="reg">
-  <code>OBJ_ATTR.attr1</code>
+  OBJ_ATTR.attr1
 </caption>
 <tr class="bits">
 	<td>F E<td>D<td>C<td>B A 9<td>8 7 6 5 4 3 2 1 0
@@ -355,7 +355,7 @@ This attribute tells the GBA which tiles to display and its background priority.
 <table class="reg" id="tbl-oe-attr2"
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
-  <code>OBJ_ATTR.attr2</code>
+  OBJ_ATTR.attr2
 </caption>
 <tr class="bits">
 	<td>F E D C<td>B A<td>9 8 7 6 5 4 3 2 1 0

--- a/content/sndsqr.md
+++ b/content/sndsqr.md
@@ -621,7 +621,7 @@ No, I'll stick to these names. Probably. Hopefully. … To be honest, I really d
 <table class="reg" 
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
-  REG_SNDDMGCNT (SOUNDCNT_L / SGCNT0_L ) @ <code>0400:0080h</code>
+  REG_SNDDMGCNT (SOUNDCNT_L / SGCNT0_L ) @ 0400:0080h
 </caption>
 <tr class="bits">
   <td>F<td>E<td>D<td>C<td>B<td>A<td>9<td>8
@@ -685,7 +685,7 @@ No, I'll stick to these names. Probably. Hopefully. … To be honest, I really d
 <table class="reg" 
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
-  REG_SNDDSCNT (SOUNDCNT_H / SGCNT0_H) @ <code>0400:0082h</code>
+  REG_SNDDSCNT (SOUNDCNT_H / SGCNT0_H) @ 0400:0082h
 </caption>
 <tr class="bits">
   <td>F<td>E<td>D<td>C<td>B<td>A<td>9<td>8
@@ -761,7 +761,7 @@ Don't know too much about `REG_SNDDSCNT`, apart from that it governs PCM sound, 
 <table class="reg" 
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
-  REG_SNDSTAT (SOUNDCNT_X / SGCNT1) @ <code>0400:0084h</code>
+  REG_SNDSTAT (SOUNDCNT_X / SGCNT1) @ 0400:0084h
 </caption>
 <tr class="bits">
   <td>F E D C B A 9 8
@@ -894,10 +894,10 @@ Both square-wave generators have registers `REG_SNDxCNT` for envelope/length/dut
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
 <span class="nobr">
-  REG_SND1CNT (SOUND1CNT_H / SG10_H) @ <code>0400:0062h</code></span>
+  REG_SND1CNT (SOUND1CNT_H / SG10_H) @ 0400:0062h</span>
   <br> and <br>
 <span class="nobr">
-  REG_SND2CNT (SOUND2CNT_L / SG20_L) @ <code>0400:0068h</code></span>
+  REG_SND2CNT (SOUND2CNT_L / SG20_L) @ 0400:0068h</span>
 </caption>
 <tr class="bits">
   <td>F E D C<td>B<td>A 9 8<td>7 6<td class="wof">5 4 3 2 1 0
@@ -1013,10 +1013,10 @@ Some more on the duty cycle. Remember we've done a Fourier analysis of the squar
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
 <span class="nobr">
-  REG_SND1FREQ (SOUND1CNT_X / SG11) @ <code>0400:0062h</code></span>
+  REG_SND1FREQ (SOUND1CNT_X / SG11) @ 0400:0062h</span>
   <br> and <br>
 <span class="nobr">
-  REG_SND2FREQ (SOUND2CNT_H / SG21) @ <code>0400:006Ch</code></span>
+  REG_SND2FREQ (SOUND2CNT_H / SG21) @ 0400:006Ch</span>
 </caption>
 <tr class="bits">
   <td class="wof">F<td>E<td>D C B
@@ -1066,7 +1066,7 @@ Some more on the duty cycle. Remember we've done a Fourier analysis of the squar
 <table class="reg" id="tbl-reg-snd1sweep" width=420
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
-  REG_SND1SWEEP (SOUND1CNT_L / SG10_L) @ <code>0400:0060h</code>
+  REG_SND1SWEEP (SOUND1CNT_L / SG10_L) @ 0400:0060h
 </caption>
 <tr class="bits">
   <td>F E D C B A 9 8 7<td>6 5 4<td>3<td>2 1 0

--- a/content/timers.md
+++ b/content/timers.md
@@ -52,7 +52,7 @@ The GBA has four timers, timers 0 to 3. Each of these has two registers: a data 
 <table class="reg" id="tbl:reg-tmxcnt"
   border=1 frame=void cellpadding=4 cellspacing=0>
 <caption class="reg">
-  REG_TMxCNT @ <code>0400:0102</code> + 4<i>x</i>
+  REG_TMxCNT @ 0400:0102 + 4<i>x</i>
 </caption>
 <tr class="bits">
 	<td>F E D C B A 9 8 <td>7 <td>6 <td>5 4 3 <td>2 <td>1 0

--- a/content/video.md
+++ b/content/video.md
@@ -92,7 +92,7 @@ The REG_DISPCNT register is the primary control of the screen. The bit-layout of
 <table class="reg" id="tbl:reg-dispcnt"
   border=1 frame=void cellPadding=4 cellSpacing=0>
 <caption class="reg">
-  REG_DISPCNT @ <code>0400:0000h</code>
+  REG_DISPCNT @ 0400:0000h
 </caption>
 <tr class="bits">
 	<td>F<td>E<td>D<td>C<td>B<td>A<td>9<td>8
@@ -176,7 +176,7 @@ Now the other two registers I mentioned, `REG_DISPSTAT` and `REG_VCOUNT`. The la
 <table class="reg" id="tbl:reg-dispstat"
   border=1 frame=void cellPadding=4 cellSpacing=0>
 <caption class="reg">
-  REG_DISPSTAT @ <code>0400:0004h</code>
+  REG_DISPSTAT @ 0400:0004h
 </caption>
 <tr class="bits">
   <td>F E D C B A 9 8
@@ -239,7 +239,7 @@ Now the other two registers I mentioned, `REG_DISPSTAT` and `REG_VCOUNT`. The la
 <table class="reg" id="tbl:reg-vcount" width="320"
   border=1 frame=void cellPadding=4 cellSpacing=0>
 <caption class="reg">
-  REG_VCOUNT @ <code>0400:0006h</code> (read-only)
+  REG_VCOUNT @ 0400:0006h (read-only)
 </caption>
 <tr class="bits">
 	<td>F E D C B A 9 8

--- a/theme/css/general.css
+++ b/theme/css/general.css
@@ -37,7 +37,7 @@
     color-scheme: var(--color-scheme);
     /* TODO: Why is important needed here? */
     --mono-font: "Fira Code" !important;
-    --mono-font-size: 1.6rem;
+    --mono-font-size: 1.4rem;
 }
 
 .sidebar {
@@ -384,11 +384,16 @@ td.fill, th.fill { width: 16px; }
 
 /* --- reg table --- */
 table.reg {
-  font: 90% var(--mono-font);
+  font: var(--mono-font-size) var(--mono-font);
   page-break-inside: avoid;
 }
-caption.reg   { caption-side:top; }
-
+caption.reg {
+  caption-side:top;
+  padding-bottom: 4px;
+}
+caption.reg, caption.reg * {
+  font-size: 1.2rem;
+}
 caption[align="bottom"], div.cblock caption[align="bottom"] {
   margin-top: 6px;
 }
@@ -399,9 +404,9 @@ caption.reg, tr.bits {
 
 tr.bits, tr.bf, col.bits, col.bf, col.def { text-align: center; }
 col.bits, col.bf, col.def { vertical-align: top; }
-tr.bits, col.bits { font: 90% var(--mono-font); }
+tr.bits, col.bits { font: var(--mono-font-size) var(--mono-font); }
 tr.bf, col.bf { font-weight: bold; }
-col.def { font: 90% var(--mono-font); }
+col.def { font: var(--mono-font-size) var(--mono-font); }
 
 /* read only, write only */
 .rof { text-decoration: overline;  color: #f22; }


### PR DESCRIPTION
This PR:
1. Cleans up the captions on register diagrams (no more thick `<code>` tags inside them)
2. Reduces the overall size of the monospaced font to fit better alongside regular text

<details>

  <summary>Before</summary>

![Screenshot from 2024-02-04 19-45-13](https://github.com/gbadev-org/tonc/assets/569607/24cd2768-34e2-4f0f-bd02-2ddd97967a3c)

</details>

<details>

  <summary>After</summary>

![Screenshot from 2024-02-04 19-33-35](https://github.com/gbadev-org/tonc/assets/569607/395258bd-c827-42d5-9830-e2355fd57ef9)

</details>

This contributes towards solving #95 but doesn't quite address the contrast issue on table borders which @djedditt mentioned.