### PR TITLE
Fixed Missing closing parentheses

### DIFF
--- a/content/intro.md
+++ b/content/intro.md
@@ -52,7 +52,7 @@ The examples depend on [libtonc](https://github.com/gbadev-org/libtonc), a libra
 
 ### Statement of Purpose {#ssec-org-sop}
 
-I wrote Tonc for two reasons. Firstly, as a way to organize my own thoughts. You often see things in a different light when you write things down and learn from that experience. Secondly, there is a lot of *very bad* information in other tutorials out there (the only exceptions I know of are the [new PERN](http://www.drunkencoders.com/web.archive.org/web/20030413142151fw_/http_/www.thepernproject.com/English/tutorial.html) and [Deku's sound tutorial](https://stuij.github.io/deku-sound-tutorial/). Yes, I am aware of how that sounds, but unfortunately it happens to be true. A number of examples:
+I wrote Tonc for two reasons. Firstly, as a way to organize my own thoughts. You often see things in a different light when you write things down and learn from that experience. Secondly, there is a lot of *very bad* information in other tutorials out there (the only exceptions I know of are the [new PERN](http://www.drunkencoders.com/web.archive.org/web/20030413142151fw_/http_/www.thepernproject.com/English/tutorial.html) and [Deku's sound tutorial](https://stuij.github.io/deku-sound-tutorial/)). Yes, I am aware of how that sounds, but unfortunately it happens to be true. A number of examples:
 
 -   Only very basic information given, sometimes even [incorrect info](affine.html).
 -   Strong focus on bitmap modes, which are hardly ever used for serious GBA programming.


### PR DESCRIPTION
On Line 55, where Cearn is talking about the other tutorials that are not innacurate, there's an opening parentheses that isn't closed. I wasn't sure whether or not to close it before or after the period, so I looked through some of the other pages and all of the other ones closed it before the period, so I matched that. 

This isn't a huge priority to merge, but it *is* one that I managed to catch and it did throw me off a little